### PR TITLE
Fix 'wxt/storage' errors in injected script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ stats-*.json
 web-ext.config.ts
 
 # Editor directories and files
-.devcontainer/devcontainer.env
 .vscode/*
 !.vscode/extensions.json
 .idea

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,8 +1,6 @@
 import { createSignal, onMount } from "solid-js";
-import {
-  type LiveChatBehavior,
-  liveChatBehaviorStorage,
-} from "~/utils/storage";
+import { liveChatBehaviorStorage } from "~/utils/storage";
+import type { LiveChatBehavior } from "~/utils/types";
 
 export default function App() {
   const [liveChatBehavior, setLiveChatBehavior] =

--- a/src/entrypoints/injected.ts
+++ b/src/entrypoints/injected.ts
@@ -1,6 +1,6 @@
 import { defineUnlistedScript } from "#imports";
 import { onLiveChatRendererReady } from "~/utils/events";
-import { isLiveChatBehavior, type LiveChatBehavior } from "~/utils/storage";
+import { isLiveChatBehavior, type LiveChatBehavior } from "~/utils/types";
 
 export default defineUnlistedScript(async () => {
   const script = document.currentScript;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,17 +1,5 @@
-import * as v from "valibot";
 import { storage } from "#imports";
-
-const liveChatBehaviorSchema = v.picklist([
-  "followDefault",
-  "forceCollapsed",
-  "forceExpanded",
-]);
-
-export type LiveChatBehavior = v.InferOutput<typeof liveChatBehaviorSchema>;
-
-export function isLiveChatBehavior(value: unknown): value is LiveChatBehavior {
-  return v.safeParse(liveChatBehaviorSchema, value).success;
-}
+import type { LiveChatBehavior } from "./types";
 
 export const liveChatBehaviorStorage = storage.defineItem<LiveChatBehavior>(
   "local:liveChatBehavior",

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,13 @@
+import * as v from "valibot";
+
+const liveChatBehaviorSchema = v.picklist([
+  "followDefault",
+  "forceCollapsed",
+  "forceExpanded",
+]);
+
+export type LiveChatBehavior = v.InferOutput<typeof liveChatBehaviorSchema>;
+
+export function isLiveChatBehavior(value: unknown): value is LiveChatBehavior {
+  return v.safeParse(liveChatBehaviorSchema, value).success;
+}


### PR DESCRIPTION
This change prevents the injected script from accidentally pulling in `wxt/storage`, which is not available in MAIN world and can trigger the runtime error.